### PR TITLE
Bugfix for multiple network training

### DIFF
--- a/cosmopower/cosmopower_NN.py
+++ b/cosmopower/cosmopower_NN.py
@@ -54,7 +54,7 @@ class cosmopower_NN(tf.keras.Model):
                  restore=False, 
                  restore_filename=None, 
                  trainable=True,
-                 optimizer=tf.keras.optimizers.Adam(),
+                 optimizer=None,
                  verbose=False, 
                  ):
         """
@@ -118,7 +118,7 @@ class cosmopower_NN(tf.keras.Model):
               self.betas[i].assign(self.betas_[i])
 
         # optimizer
-        self.optimizer = optimizer
+        self.optimizer = optimizer or tf.keras.optimizers.Adam()
         self.verbose= verbose
 
         # print initialization info, if verbose

--- a/cosmopower/cosmopower_PCAplusNN.py
+++ b/cosmopower/cosmopower_PCAplusNN.py
@@ -40,7 +40,7 @@ class cosmopower_PCAplusNN(tf.keras.Model):
                  restore=False, 
                  restore_filename=None, 
                  trainable=True, 
-                 optimizer=tf.keras.optimizers.Adam(),
+                 optimizer=None,
                  verbose=False,
                  ):
         r"""
@@ -121,7 +121,7 @@ class cosmopower_PCAplusNN(tf.keras.Model):
                 self.alphas[i].assign(self.alphas_[i])
                 self.betas[i].assign(self.betas_[i])
 
-        self.optimizer = optimizer
+        self.optimizer = optimizer or tf.keras.optimizers.Adam()
         self.verbose= verbose
 
         # print initialization info, if verbose


### PR DESCRIPTION
When training multiple networks in a row, a bug appears related to default parameters.

Essentially, attempting something like this:

```
nn_1 = cp.cosmopower_NN(...)
nn_1.train(...)

nn_2 = cp.cosmopower_NN(...)
nn_2.train(...)
```

can cause an issue within Tensorflow. This is caused by the `optimizer = tf.keras.optimizers.Adam()` default parameter of `cosmopower_NN` and `cosmopower_PCAplusNN` - it causes both networks to use the same optimizer object rather than creating a new one individually, which freaks out TF when training the second network.

This pull request fixes it by making the cosmopower object instantiate the optimizer during the `__init__()` call instead of in its defaults parameters.