### PR TITLE
Version 0.1.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(classifiers=['Operating System :: OS Independent',
                    'Intended Audience :: Science/Research'
                   ],
       name='cosmopower',
-      version='v0.1.0',
+      version='v0.1.1',
       description='Machine Learning - accelerated Bayesian inference',
       long_description_content_type = "text/markdown",
       long_description = long_description,


### PR DESCRIPTION
- updates pip-installable version changing deprecated requirement syntax `sklearn` to `scikit-learn`