### PR TITLE
Add TensorFlow < 2.14 requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,5 @@ mkdocstrings
 matplotlib
 pytest
 pyDOE
+tensorflow<2.14
 tensorflow_probability


### PR DESCRIPTION
In line with what explained in https://github.com/alessiospuriomancini/cosmopower/issues/22, we need this to avoid errors when loading a pickled model.