### PR TITLE
Specify TFP requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ matplotlib
 pytest
 pyDOE
 tensorflow<2.14
-tensorflow_probability
+tensorflow_probability<0.22


### PR DESCRIPTION
As per https://github.com/alessiospuriomancini/cosmopower/issues/24, we also need to ask for TFP < 0.22, otherwise the API breaks.